### PR TITLE
updating PWHL rosters & play-by-play

### DIFF
--- a/R/pwhl_stat_leaders.R
+++ b/R/pwhl_stat_leaders.R
@@ -69,6 +69,9 @@ pwhl_stats <- function(position = "goalie", team = "BOS", season = 2023, regular
           players <- dplyr::bind_rows(players, player_df)
 
         }
+
+        players <- players %>%
+          tidyr::separate("minutes", into = c("minute", "second"), sep = ":", remove = FALSE)
       } else {
         URL <- glue::glue("https://lscluster.hockeytech.com/feed/index.php?feed=statviewfeed&view=players&season={season_id}&team={team_id}&position=skaters&rookies=0&statsType=standard&rosterstatus=undefined&site_id=2&first=0&limit=20&sort=points&league_id=1&lang=en&division=-1&key=694cfeed58c932ee&client_code=pwhl&league_id=1&callback=angular.callbacks._6")
 

--- a/R/pwhl_team_roster.R
+++ b/R/pwhl_team_roster.R
@@ -78,15 +78,18 @@ pwhl_team_roster <- function(team, season, regular = TRUE) {
               hand <- players[[i]]$data[[p]]$row$shoots
             }
 
+            "player_id" %in% names(players[[i]]$data[[p]]$row)
+
             player_info <- data.frame(
-              "player_id" = c(players[[i]]$data[[p]]$row$player_id),
-              "player_name" = c(players[[i]]$data[[p]]$row$name),
+              "player_id" = c(if ("player_id" %in% names(players[[i]]$data[[p]]$row)) players[[i]]$data[[p]]$row$player_id else NA),
+              "player_name" = c(if ("name" %in% names(players[[i]]$data[[p]]$row)) players[[i]]$data[[p]]$row$name else NA),
               "primary_hand" = c(hand),
-              "dob" = c(players[[i]]$data[[p]]$row$birthdate),
-              "height" = c(players[[i]]$data[[p]]$row$height_hyphenated),
-              "position" = c(players[[i]]$data[[p]]$row$position),
-              "home_town" = c(players[[i]]$data[[p]]$row$hometown)
-            )
+              "dob" = c(if ("birthdate" %in% names(players[[i]]$data[[p]]$row)) players[[i]]$data[[p]]$row$birthdate else NA),
+              "height" = c(if ("height_hyphenated" %in% names(players[[i]]$data[[p]]$row)) players[[i]]$data[[p]]$row$height_hyphenated else NA),
+              "position" = c(if ("position" %in% names(players[[i]]$data[[p]]$row)) players[[i]]$data[[p]]$row$position else NA),
+              "home_town" = c(if ("hometown" %in% names(players[[i]]$data[[p]]$row)) players[[i]]$data[[p]]$row$hometown else NA)
+            ) %>%
+              tidyr::separate(player_name, into = c("first_name", "last_name"), remove = FALSE, sep=" ")
 
             # players[[i]]$data[[p]]$prop
 
@@ -103,10 +106,12 @@ pwhl_team_roster <- function(team, season, regular = TRUE) {
 
       roster_data <- roster_data %>%
         dplyr::mutate(
+          league = "pwhl",
           age = round(lubridate::time_length(as.Date(paste0(season, "-01-01")) - as.Date(.data$dob), "years")),
           player_headshot = paste0("https://assets.leaguestat.com/pwhl/240x240/", .data$player_id, ".jpg"),
           regular_season = ifelse(season_id == 1, TRUE, FALSE),
-          season = season
+          season = season,
+          player_id = as.numeric(player_id)
         )
     },
     error = function(e) {


### PR DESCRIPTION
updated PWHL play-by-play
- includes improved power-play / short-hand designations for shots and faceoffs in addition to the existing goals
- updated some of the clock / time etc metrics to make them more workable (i.e. a "total second of the game" type column)
- shot coordinate fixes. `coord_original` is the original coordinate from the PWHL API. `x/y_coord` is the fixed coordinate that is split with the home team on the left and the home team on the right. `coord_right` is all the coords flipped over to so that the target goal is on the right side of the rink. `coord_vertical` is flipped so that the target goal is up, rotated -90 degrees from coord_right.
- fixed pwhl roster bug
- added a better time on ice metric for goalie (converted from 214:14 to like 214.24 minutes)